### PR TITLE
ci: trigger lint and test before release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - reopened
       - synchronize
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,19 @@ on:
       - main
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+  test:
+    uses: ./.github/workflows/test.yml
+    secrets:
+      CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
   release-please:
+    needs:
+      - lint
+      - test
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3
@@ -16,6 +28,20 @@ jobs:
           release-type: ruby
           token: ${{secrets.GITHUB_TOKEN}}
           version-file: "lib/rack/idempotency_key/version.rb"
+          changelog-types: >
+            [
+              { "type": "build", "section": "Build System", "hidden": false },
+              { "type": "ci", "section": "Continuous Integration", "hidden": false },
+              { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
+              { "type": "docs", "section": "Documentation", "hidden": false },
+              { "type": "feat", "section": "Features", "hidden": false },
+              { "type": "fix", "section": "Bug Fixes", "hidden": false },
+              { "type": "perf", "section": "Performance Improvements", "hidden": false },
+              { "type": "revert", "section": "Reverts", "hidden": false },
+              { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+              { "type": "style", "section": "Styles", "hidden": false },
+              { "type": "test", "section": "Tests", "hidden": false }
+            ]
       - uses: actions/checkout@v4
         if: ${{steps.release.outputs.release_created}}
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Improvements**
	- Enhanced GitHub Actions workflow by adding lint and test jobs to the release process
	- Improved release workflow with explicit job dependencies and permissions
	- Updated changelog generation with more structured entry types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->