### PR TITLE
feat: allow redis store to receive a connection pool

### DIFF
--- a/lib/rack/idempotency_key/memory_store.rb
+++ b/lib/rack/idempotency_key/memory_store.rb
@@ -5,7 +5,7 @@ require "rack/idempotency_key/store"
 module Rack
   class IdempotencyKey
     class MemoryStore < Store
-      def initialize(store = {}, expires_in: 86_400)
+      def initialize(store = {}, expires_in: Store::DEFAULT_EXPIRATION)
         super(store, expires_in: expires_in)
         @mutex = Mutex.new
       end

--- a/lib/rack/idempotency_key/redis_store.rb
+++ b/lib/rack/idempotency_key/redis_store.rb
@@ -9,25 +9,45 @@ module Rack
     class RedisStore < Store
       KEY_NAMESPACE = "idempotency_key"
 
-      def initialize(store, expires_in: 86_400)
-        super(store, expires_in: expires_in)
-      end
-
       def get(key)
-        value = store.get(namespaced_key(key))
+        value = with_redis { |redis| redis.get(namespaced_key(key)) }
         JSON.parse(value) unless value.nil?
       rescue Redis::BaseError => e
         raise Rack::IdempotencyKey::Store::Error, "#{self.class}: #{e.message}"
       end
 
       def set(key, value)
-        store.set(namespaced_key(key), value, nx: true, ex: expires_in)
+        with_redis { |redis| redis.set(namespaced_key(key), value, nx: true, ex: expires_in) }
         get(key)
       rescue Redis::BaseError => e
         raise Rack::IdempotencyKey::Store::Error, "#{self.class}: #{e.message}"
       end
 
       private
+
+        # Executes the given block with a Redis connection, supporting both direct
+        # Redis instances and connection pools (https://github.com/mperham/connection_pool).
+        #
+        # If a `ConnectionPool` is detected (by responding to `with`), it will yield a Redis
+        # connection from the pool. Otherwise, it will yield the direct Redis instance.
+        #
+        # @yieldparam redis [Redis] A Redis connection instance.
+        # @return [Object] The result of the block execution.
+        #
+        # @example Using a direct Redis instance
+        #   store = RedisStore.new(Redis.new)
+        #   store.with_redis { |redis| redis.set("key", "value") }
+        #
+        # @example Using a Redis connection pool
+        #   store = RedisStore.new(ConnectionPool.new(size: 5, timeout: 5) { Redis.new })
+        #   store.with_redis { |redis| redis.set("key", "value") }
+        def with_redis(&block)
+          if store.respond_to?(:with)
+            store.with(&block)
+          else
+            yield store
+          end
+        end
 
         def namespaced_key(key)
           "#{KEY_NAMESPACE}:#{key.split.join}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated default expiration time in `MemoryStore` to use a predefined constant
	- Simplified `RedisStore` constructor and added a new method for more flexible Redis connection handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->