### PR TITLE
feat: add request hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ Rack::IdempotencyKey::RedisStore.new(Redis.current)
 Rack::IdempotencyKey::RedisStore.new(Redis.current, expires_in: 300)
 ```
 
-Every key written to Redis will get prefixed with `idempotency_key` to avoid conflicts on shared instances.
-
 If you're using a [Connection Pool](https://github.com/mperham/connection_pool), you can pass it instead of the single instance:
 
 ```ruby

--- a/lib/rack/idempotency_key/request_hash.rb
+++ b/lib/rack/idempotency_key/request_hash.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Rack
+  class IdempotencyKey
+    class RequestHash
+      def initialize(rack_request)
+        @rack_request = rack_request
+      end
+
+      # Generates a unique SHA-256 hash to identify the request.
+      #
+      # The hash is constructed using the request method, full path, idempotency key,
+      # authorization header, and the request body (if available and rewindable).
+      #
+      # This ensures that requests with identical content produce the same fingerprint,
+      # supporting idempotency while preventing accidental collisions between different clients.
+      #
+      # @return [String] A SHA-256 hexadecimal digest representing the request fingerprint.
+      def id
+        digest = Digest::SHA256.new
+        digest.update(rack_request.request_method)
+        digest.update(rack_request.fullpath)
+        digest.update(idempotency_key_header)
+        digest.update(authorization_header)
+        update_with_request_body_chunks(digest)
+        digest.hexdigest
+      end
+
+      private
+
+        attr_reader :rack_request
+
+        # Retrieves the `Idempotency-Key` header from the request. If the header is missing,
+        # it defaults to `"no-idempotency-key"` to ensure that the request can still be processed
+        # while clearly indicating the absence of an explicit idempotency key.
+        def idempotency_key_header
+          rack_request.get_header("HTTP_IDEMPOTENCY_KEY") || "no-idempotency-key"
+        end
+
+        # Retrieves the Authorization header from the request. If the header is missing,
+        # defaults to "no-authorization" to indicate the absence of credentials.
+        def authorization_header
+          rack_request.get_header("HTTP_AUTHORIZATION") || "no-authorization"
+        end
+
+        # Updates the given digest with the request body content. If the body is non-rewindable
+        # (e.g., a streaming request), it appends a predefined "streaming-body" marker instead.
+        # Otherwise, it reads the body in 8KB chunks for efficient hashing and ensures the stream
+        # is rewound after processing.
+        #
+        # @param digest [Digest::SHA256]
+        def update_with_request_body_chunks(digest)
+          return digest.update("streaming-body") unless rack_request.body.respond_to?(:rewind)
+
+          begin
+            while (chunk = rack_request.body.read(8192))
+              digest.update(chunk)
+            end
+          ensure
+            rack_request.body.rewind
+          end
+        end
+    end
+  end
+end

--- a/spec/rack/idempotency_key/request_hash_spec.rb
+++ b/spec/rack/idempotency_key/request_hash_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rack/test"
+
+require "digest"
+require "stringio"
+
+RSpec.describe Rack::IdempotencyKey::RequestHash do
+  include Rack::Test::Methods
+
+  subject(:request_hash) { described_class.new(rack_request) }
+
+  let(:rack_request)    { Rack::Request.new(env) }
+  let(:env)             { Rack::MockRequest.env_for(env_uri, env_opts) }
+  let(:env_uri)         { "/" }
+  let(:env_opts)        { {} }
+  let(:idempotency_key) { "123456789" }
+  let(:bearer_token)    { "Bearer token123" }
+
+  shared_examples "a different id when the env changes" do
+    let(:new_request)      { Rack::Request.new(new_env) }
+    let(:new_request_hash) { described_class.new(new_request) }
+
+    it { is_expected.not_to eq(new_request_hash.id) }
+  end
+
+  before do
+    env["HTTP_IDEMPOTENCY_KEY"] = idempotency_key
+    env["HTTP_AUTHORIZATION"]   = bearer_token
+    env["rack.input"]           = StringIO.new("The request body")
+  end
+
+  describe "#id" do
+    subject(:id) { request_hash.id }
+
+    it "generates a consistent SHA-256 hash for the same request" do
+      same_id_one = request_hash.id
+      same_id_two = request_hash.id
+
+      expect(same_id_one).to eq(same_id_two)
+    end
+
+    context "without the idempotency key header" do
+      let(:constant_id) { "3d5b6059f39c534bd5731f870d2329287f12c4db44660573e89df794fd229de9" }
+
+      before { env.delete("HTTP_IDEMPOTENCY_KEY") }
+
+      it { is_expected.to eq(constant_id) }
+    end
+
+    context "without the authorization header" do
+      let(:constant_id) { "596ec3d0f0735d982a8de4311141df0fdeea7c7bc4fdb71bce4a5342d65415df" }
+
+      before { env.delete("HTTP_AUTHORIZATION") }
+
+      it { is_expected.to eq(constant_id) }
+    end
+
+    context "without the request body" do
+      let(:constant_id) { "15262d80b3fda7fb2ac47de1c9e6cf2ffa750e53fb72da593752163fed84c458" }
+
+      before { env.delete("rack.input") }
+
+      it { is_expected.to eq(constant_id) }
+    end
+
+    context "with a different request method" do
+      let(:new_env) { env.merge("REQUEST_METHOD" => "POST") }
+
+      include_examples "a different id when the env changes"
+    end
+
+    context "with a different request path" do
+      let(:new_env) { env.merge("PATH_INFO" => "/api/other-resource") }
+
+      include_examples "a different id when the env changes"
+    end
+
+    context "with a different idempotency key header" do
+      let(:new_env) { env.merge("HTTP_IDEMPOTENCY_KEY" => "different-key") }
+
+      include_examples "a different id when the env changes"
+    end
+
+    context "with a different authorization header" do
+      let(:new_env) { env.merge("HTTP_AUTHORIZATION" => "Bearer another-token") }
+
+      include_examples "a different id when the env changes"
+    end
+
+    context "with a different request body" do
+      let(:new_env) { env.merge("rack.input" => StringIO.new("Another body")) }
+
+      include_examples "a different id when the env changes"
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `RequestHash` class for generating unique request identifiers.
	- Enhanced request idempotency handling with more robust key generation.

- **Refactor**
	- Simplified Redis key storage by removing namespace handling.
	- Updated request caching mechanism to use new request ID.

- **Tests**
	- Added comprehensive test suite for the new `RequestHash` class to ensure consistent request identification.

- **Documentation**
	- Added warnings regarding the pre-1.0 release phase of the `Rack::IdempotencyKey` gem.
	- Expanded explanations on idempotent operations and caching mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->